### PR TITLE
fix: 修复用户管理页面通过部门无法查询到用户

### DIFF
--- a/eladmin/eladmin-system/src/main/resources/mapper/system/UserMapper.xml
+++ b/eladmin/eladmin-system/src/main/resources/mapper/system/UserMapper.xml
@@ -60,9 +60,6 @@
             <if test="criteria.enabled != null">
                 and u.enabled = #{criteria.enabled}
             </if>
-            <if test="criteria.deptId != null">
-                and u.dept_id = #{criteria.deptId}
-            </if>
             <if test="criteria.deptIds != null and criteria.deptIds.size() != 0">
                 and u.dept_id in
                 <foreach collection="criteria.deptIds" item="deptId" open="(" separator="," close=")">


### PR DESCRIPTION
 如果在用户管理页面选择一个顶级部门，最终SQL条件为：WHERE u.dept_id = 7 AND u.dept_id in ( 17 , 2 , 5 , 7 )，用户如果不在顶级部门，会查询不到，在Controller代码中已经将父节点和子节点都添加在了集合中，所以可以去除u.dept_id = #{criteria.deptId} 条件。