### PR TITLE
fix: QuartzLogMapper动态SQL布尔类型测试条件错误

### DIFF
--- a/eladmin/eladmin-system/src/main/resources/mapper/quartz/QuartzLogMapper.xml
+++ b/eladmin/eladmin-system/src/main/resources/mapper/quartz/QuartzLogMapper.xml
@@ -27,7 +27,7 @@
             <if test="criteria.jobName != null and criteria.jobName != ''">
                 AND job_name LIKE CONCAT('%',#{criteria.jobName},'%')
             </if>
-            <if test="criteria.isSuccess != null and criteria.isSuccess != ''">
+            <if test="criteria.isSuccess != null">
                 AND is_success = #{criteria.isSuccess}
             </if>
             <if test="criteria.createTime != null and criteria.createTime.size() > 0">


### PR DESCRIPTION
MyBatis-Plus 版本QuartzLogMapper动态SQL布尔类型测试条件错误，造成任务调度模块日志查询功能日志状态(成功/失败)筛选无效。