### PR TITLE
fix: 分页查询场景时，用户列表倒叙排序失效

### DIFF
--- a/eladmin/eladmin-system/src/main/resources/mapper/system/UserMapper.xml
+++ b/eladmin/eladmin-system/src/main/resources/mapper/system/UserMapper.xml
@@ -90,6 +90,7 @@
             left join sys_dept d on u.dept_id = d.dept_id
             <include refid="Whrer_Sql"/>
             <if test="criteria.offset != null">
+                order by u.user_id desc
                 limit #{criteria.offset}, #{criteria.size}
             </if>
         ) u


### PR DESCRIPTION
当用户列表的数据大于页的大小时，新增的用户就无法在第一页显示，这应该不是预期的效果。