### PR TITLE
解决可能出现的用户列表排序不正确问题

### DIFF
--- a/eladmin/eladmin-system/src/main/resources/mapper/system/UserMapper.xml
+++ b/eladmin/eladmin-system/src/main/resources/mapper/system/UserMapper.xml
@@ -90,15 +90,15 @@
         left join sys_dept d on u.dept_id = d.dept_id
         <include refid="Whrer_Sql"/>
         order by u.user_id desc
-        <if test="criteria.offset != null">
-            limit #{criteria.offset}, #{criteria.size}
-        </if>
         ) u
         left join sys_users_jobs suj on u.user_user_id = suj.user_id
         left join sys_job j on suj.job_id = j.job_id
         left join sys_users_roles sur on u.user_user_id = sur.user_id
         left join sys_role r on sur.role_id = r.role_id
         order by u.user_user_id desc
+        <if test="criteria.offset != null">
+            limit #{criteria.offset}, #{criteria.size}
+        </if>
     </select>
 
     <select id="countAll" resultType="java.lang.Long">


### PR DESCRIPTION
admin账号是最早加入的账号，排序规则是根据user_id逆序，admin应该排在第二页，但是却排在第一页。

<img width="2378" height="1784" alt="1" src="https://github.com/user-attachments/assets/b9e1d66d-783d-4a1a-9f23-0d611c5b5a5b" />
<img width="2904" height="1778" alt="2" src="https://github.com/user-attachments/assets/df257d5b-c4bf-4e74-b5d9-6842ff0b5eeb" />

